### PR TITLE
Proposed fix for fail report.

### DIFF
--- a/lib/Perl/Critic/Policy/TryTiny/ProhibitExitingSubroutine.pm
+++ b/lib/Perl/Critic/Policy/TryTiny/ProhibitExitingSubroutine.pm
@@ -88,8 +88,8 @@ sub _check_block {
     my $wanted;
     $wanted = sub {
         my ($parent, $element, $in_for_loop, $in_sub_block) = @_;
-        $in_for_loop //= 0;
-        $in_sub_block //= 0;
+        $in_for_loop = (defined $in_for_loop) ? $in_for_loop : 0;
+        $in_sub_block = (defined $in_sub_block) ? $in_sub_block : 0;
 
         if ($element->isa('PPI::Statement::Compound')) {
             if ( $element->type eq 'for' || $element->type eq 'foreach') {


### PR DESCRIPTION
Hi @Flimm 

Please review the PR.
This PR propose to resolve the fail report below.

https://www.cpantesters.org/cpan/report/42f8935c-5be5-11e7-a074-e1beba07c9dd

Since the dist.ini using plugin [AutoPrereqs] it guessed the minimum perl version is 5.6.0 because of the line 2: "use 5.006;" in the unit test "t/pod.t". However the following 2 lines in the package Perl::Critic::Policy::TryTiny::ProhibitExitingSubroutine is using "Logical Defined-Or" operator introduced in v5.10.0 only. So the solution is either set the minimum perl to v5.10 or don't use Logical Defined-Or. In my humble opinion, it is better to skip the use Logical Defined-Or and keep the minimum perl v5.6.

          92:     $in_for_loop //= 0;
          93:     $in_sub_block //= 0;

is now looks like

           92:     $in_for_loop = (defined $in_for_loop) ? $in_for_loop : 0;
           93:     $in_sub_block = (defined $in_sub_block) ? $in_sub_block : 0;

Many Thanks.
Best Regards,
Mohammad S Anwar